### PR TITLE
Fix stats par type de financeur

### DIFF
--- a/class/subventionstats.class.php
+++ b/class/subventionstats.class.php
@@ -248,7 +248,7 @@ class SubventionStats extends Stats
 				$sql .= " AND ".dolSqlDateFilter('x.'.$this->date_stat, 0, 0, (int) $year, 1);
 			}
 			$sql .= " GROUP BY x.fk_financeur";
-			$sql .= $this->db->order('nom', 'ASC');
+			$sql .= $this->db->order('fk_financeur', 'ASC');
 		}
 		else {
 			$sql = "SELECT x.fk_soc, COUNT(x.ref) AS nb, x.montant_dem, x.montant_acc, x.montant_fin, x.date_creation, s.nom";

--- a/class/subventionstats.class.php
+++ b/class/subventionstats.class.php
@@ -274,6 +274,7 @@ class SubventionStats extends Stats
 					'montant_fin' => $obj->montant_fin,
 					'date_creation' => $obj->date_creation,
 					'nom' => $obj->nom,
+					'fk_financeur' => $obj->fk_financeur,
 				);
 				$i++;
 			}

--- a/class/subventionstats.class.php
+++ b/class/subventionstats.class.php
@@ -223,7 +223,8 @@ class SubventionStats extends Stats
 	 */
 	public function getAllByYear()
 	{
-		$sql = "SELECT date_format(x.".$this->date_stat.",'%Y') as year, count(*) as nb, sum(x.".$this->montant.") as total, avg(x.".$this->montant.") as avg";
+		$this->date_stat = getDolGlobalString('SUBVENTIONS_STATISTIC_DATE');
+		$sql = "SELECT date_format(".$this->date_stat.",'%Y') as year, count(*) as nb, sum(x.".$this->montant.") as total, avg(x.".$this->montant.") as avg";
 		$sql .= " FROM ".$this->from;
 		$sql .= " WHERE ".$this->where;
 		$sql .= " GROUP BY year";
@@ -236,25 +237,30 @@ class SubventionStats extends Stats
 	 *	Récupérer tous les financeurs, nb demandes, mnt deamndé, mnt accepté, mnt financé, dernière demande
 	 *
 	 *  @return array<array{fk_soc:int,nb:int,montant_dem:float,montant_acc:float,montant_fin:float,date_creation:date,nom:string}>
+	 *  Use SUBVENTIONS_STATISTIC_DATE as filter for date of last request, if not set, use date_creation
 	 */
 	public function getStatsFundingSource($sumary, $year = 0)
 	{
+		$this->date_stat = getDolGlobalString('SUBVENTIONS_STATISTIC_DATE');
 		if ($sumary){
-			$sql = "SELECT x.fk_soc, COUNT(x.ref) AS nb, x.montant_dem, x.montant_acc, x.montant_fin, x.date_creation, x.fk_financeur, s.label as nom";
+			$sql = "SELECT x.fk_soc, COUNT(x.ref) AS nb, SUM(x.montant_dem) as montant_dem, SUM(x.montant_acc) as montant_acc, SUM(x.montant_fin) as montant_fin, COALESCE(y.".$this->date_stat.", y.date_creation) as date, x.fk_financeur, s.label as nom";
 			$sql .= " FROM ".$this->from;
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_subventions_financeur as s ON s.rowid = x.fk_financeur";
 			$sql .= " WHERE ".$this->where;
 			if ($year > 0) {
-				$sql .= " AND ".dolSqlDateFilter('x.'.$this->date_stat, 0, 0, (int) $year, 1);
+				$sql .= " AND ".dolSqlDateFilter('y.'.$this->date_stat, 0, 0, (int) $year, 1);
 			}
 			$sql .= " GROUP BY x.fk_financeur";
-			$sql .= $this->db->order('fk_financeur', 'ASC');
+			$sql .= $this->db->order('s.position', 'ASC');
 		}
 		else {
-			$sql = "SELECT x.fk_soc, COUNT(x.ref) AS nb, x.montant_dem, x.montant_acc, x.montant_fin, x.date_creation, s.nom";
+			$sql = "SELECT x.fk_soc, COUNT(x.ref) AS nb, SUM(x.montant_dem) as montant_dem, SUM(x.montant_acc) as montant_acc, SUM(x.montant_fin) as montant_fin, COALESCE(y.".$this->date_stat.", y.date_creation) as date, s.nom";
 			$sql .= " FROM ".$this->from;
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON s.rowid = x.fk_soc";
 			$sql .= " WHERE ".$this->where;
+			if ($year > 0) {
+				$sql .= " AND ".dolSqlDateFilter('y.'.$this->date_stat, 0, 0, (int) $year, 1);
+			}
 			$sql .= " GROUP BY x.fk_soc";
 			$sql .= $this->db->order('s.nom', 'ASC');
 		}
@@ -272,9 +278,9 @@ class SubventionStats extends Stats
 					'montant_dem' => $obj->montant_dem,
 					'montant_acc' => $obj->montant_acc,
 					'montant_fin' => $obj->montant_fin,
-					'date_creation' => $obj->date_creation,
+					'date_creation' => $obj->date,
 					'nom' => $obj->nom,
-					'fk_financeur' => $obj->fk_financeur,
+					'fk_financeur' => $obj->fk_financeur
 				);
 				$i++;
 			}

--- a/stats/statistics_fundingsource.php
+++ b/stats/statistics_fundingsource.php
@@ -289,6 +289,12 @@ print '</tr>';
 
 print '</div></table>';
 
+// Réinitialisation des totaux
+$total_nb = 0;
+$total_montant_dem = 0;
+$total_montant_acc = 0;
+$total_montant_fin = 0;
+
 // Liste complète des financeurs
 print '<div class="div-table-responsive-no-min">';
 print '<table class="noborder centpercent">';

--- a/stats/statistics_fundingsource.php
+++ b/stats/statistics_fundingsource.php
@@ -256,7 +256,7 @@ foreach ($data as $val) {
 	else {$colorFinAcc = 'red';}
 
     print '<tr class="oddeven" height="24">';
-    print '<td align="left"><a href="'.dol_buildpath('custom/subventions/financement_list.php?search_fk_soc='.$val['fk_soc'].'">'.$val['nom'],1).'</a></td>';
+    print '<td align="left"><a href="'.dol_buildpath('custom/subventions/financement_list.php?search_fk_financeur='.$val['fk_financeur'].'">'.$val['nom'],1).'</a></td>';
     print '<td class="center">'.$val['nb'].'</td>';
     print '<td class="right"><span class="amount">'.price(price2num($val['montant_dem'], 'MT'), 1).'</span></td>';
     print '<td class="right"><span class="amount">'.price(price2num($val['montant_acc'], 'MT'), 1).'</span></td>';


### PR DESCRIPTION
Le lien par groupe de financeurs pointait vers fk_soc au lieu de fk_financeur et affichait les financements d'un seul financeur du groupe et non de la totalité des financeurs du groupe.

Corrige #24 en triant les résultats par l'ordre configuré dans le dictionnaire.

Corrige le filtrage par année.

Corrige les totaux erronés (non remis à zéro entre 2 tableaux).

Applique le filtre par année sur le deuxième tableau de la page.