### PR TITLE
Fix montant refusé négatif si montant demandé < montant accordé.

### DIFF
--- a/lib/subventions.lib.php
+++ b/lib/subventions.lib.php
@@ -175,7 +175,8 @@ function majMontantsFinancementSubvention($object) {
                 $m_ref = 0;    
             }
             else{
-                $m_ref = $m_dem - $m_acc;
+                // Calcule le montant refusé (montant_dem - montant_acc) ne peut pas être négatif
+                $m_ref = ($m_dem - $m_acc < 0) ? 0 : $m_dem - $m_acc;
             }
 
             // Màj financement

--- a/lib/subventions.lib.php
+++ b/lib/subventions.lib.php
@@ -167,8 +167,8 @@ function majMontantsFinancementSubvention($object) {
             $obj = $db->fetch_object($resql);
             $m_fin = (float) $obj->total;
 
-            // Calcule le montant attendu (montant_acc - somme des paiements)
-            $m_att = $m_acc - $m_fin;
+            // Calcule le montant attendu (montant_acc - somme des paiements) ne peut pas être négatif
+            $m_att = ($m_acc - $m_fin < 0) ? 0 : $m_acc - $m_fin;
             
             // Si aucun montant n'a été saisi on ne calcul rien
             if (is_null($m_acc)){


### PR DESCRIPTION
Dans l'éventualité où il n'y aurait pas de montant demandé (montant_dem = 0 ) ou si le montant accordé est supérieur au montant demandé, évite de calculer un montant refusé négatif qui affecte les statistiques.

Corrige également le montant attendu.